### PR TITLE
Use newer theme properties in Firefox 65+

### DIFF
--- a/background.js
+++ b/background.js
@@ -55,11 +55,11 @@ class containersTheme {
     this.cachedCookieStore = currentCookieStore;
     return browser.theme.update(windowId, {
       images: {
-        headerURL: "",
+        theme_frame: "",
       },
       colors: {
-        accentcolor: container.colorCode,
-        textcolor: "#111",
+        frame: container.colorCode,
+        tab_background_text: "#111",
       }
     });
   }

--- a/background.js
+++ b/background.js
@@ -1,12 +1,18 @@
 class containersTheme {
   constructor() {
-    browser.tabs.onActivated.addListener(() => {
+    browser.runtime.getBrowserInfo().then(info => {
+      const version = info.version.match(/^(\d+)/);
+      this.useThemePropertiesWhenOlderThanFirefox65 = (version < 65);
+
+      browser.tabs.onActivated.addListener(() => {
+        this.getCurrentContainer();
+      });
+      browser.windows.onFocusChanged.addListener(() => {
+        this.getCurrentContainer();
+      });
+
       this.getCurrentContainer();
     });
-    browser.windows.onFocusChanged.addListener(() => {
-      this.getCurrentContainer();
-    });
-    this.getCurrentContainer();
   }
 
   async getCurrentContainer() {
@@ -53,7 +59,8 @@ class containersTheme {
 
   async changeTheme(currentCookieStore, windowId, container) {
     this.cachedCookieStore = currentCookieStore;
-    return browser.theme.update(windowId, {
+
+    const theme = {
       images: {
         theme_frame: "",
       },
@@ -61,7 +68,25 @@ class containersTheme {
         frame: container.colorCode,
         tab_background_text: "#111",
       }
-    });
+    };
+
+    if (this.useThemePropertiesWhenOlderThanFirefox65) {
+      this.transformThemeForOlderThanFirefox65(theme);
+    }
+
+    return browser.theme.update(windowId, theme);
+  }
+
+  transformThemeForOlderThanFirefox65(theme) {
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#Aliases
+
+    theme.images.headerUrl = theme.images.theme_frame;
+    theme.colors.accentcolor = theme.colors.frame;
+    theme.colors.textcolor = theme.colors.tab_background_text;
+
+    delete theme.images.theme_frame;
+    delete theme.colors.frame;
+    delete theme.colors.tab_background_text;
   }
 
 }

--- a/manifest.json
+++ b/manifest.json
@@ -21,5 +21,5 @@
   "description": "Change theme colour based on your container color",
   "manifest_version": 2,
   "name": "Containers theme",
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "containers-theme",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Changes the current browser window theme to match the colour of the active tab.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Fixes #9.

See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#Aliases for the details of the deprecated properties on `theme`.