### PR TITLE
bugfix: get default containers to return to default theme color

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -19,19 +19,18 @@ class containersTheme {
     const activeTabs = await browser.tabs.query({
       active: true
     });
-    const hasUnpainted = activeTabs.some((tab) => {
-      return this.isUnpaintedTheme(tab.cookieStoreId);
-    });
+
     const containers = await this.getContainers();
-    if (hasUnpainted) {
-      this.resetTheme();
-    }
+
     activeTabs.forEach((tab) => {
       const cookieStoreId = tab.cookieStoreId;
       if (!this.isUnpaintedTheme(cookieStoreId)) {
         this.changeTheme(cookieStoreId,
           tab.windowId,
           containers.get(cookieStoreId));
+      }
+      else {
+        this.resetTheme(tab.windowId);
       }
     });
   }
@@ -47,14 +46,11 @@ class containersTheme {
 
   isUnpaintedTheme(currentCookieStore) {
     return (currentCookieStore == "firefox-default" ||
-            currentCookieStore == "firefox-private");
+      currentCookieStore == "firefox-private");
   }
 
-  resetTheme() {
-    // Because of the following, we loop through all active windows after a reset
-    // this means when we have unpained tabs the browser flickers
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1401691
-    browser.theme.reset();
+  resetTheme(windowId) {
+    browser.theme.reset(windowId);
   }
 
   async changeTheme(currentCookieStore, windowId, container) {


### PR DESCRIPTION
passing in the `tab.windowID` to the resetTheme function as well as removing the `hasUnpainted` check and replacing it with an else statement seemed to do the trick.

I mostly figured this out by just poking around and looking at the [docs for browser.theme.reset](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/theme/reset), so I'm not 100% sure WHY these changes work ..